### PR TITLE
chore: update action to new repository location

### DIFF
--- a/.github/workflows/publish_secrets.yml
+++ b/.github/workflows/publish_secrets.yml
@@ -5,7 +5,7 @@ jobs:
     permissions: write-all
     runs-on: ubuntu-latest
     steps:
-      - uses: google/secrets-sync-action@v1.4.1
+      - uses: jpoehnelt/secrets-sync-action@v1.4.1
         with:
           # Modify this "secrets" regex so that your provided secrets pass the match.
           SECRETS: |


### PR DESCRIPTION
This is a PR to update the action to the new repository location from https://github.com/google/secrets-sync-action to https://github.com/jpoehnelt/secrets-sync-action. Note that GitHub does redirect the old repository to the new one, so this is more housekeeping than anything else.